### PR TITLE
Fix method description with mapping writer

### DIFF
--- a/src/matcher/type/MethodInstance.java
+++ b/src/matcher/type/MethodInstance.java
@@ -98,7 +98,7 @@ public class MethodInstance extends MemberInstance<MethodInstance> {
 			ret += arg.id;
 		}
 
-		ret += ")" + retType.getName();
+		ret += ")" + retType.getId() + retType.getName() + ";";
 
 		return ret;
 	}


### PR DESCRIPTION
This fixes getDesc not having the return type id, and not ending with the semicolon.