### PR TITLE
Fix assignMissing flattening all fields

### DIFF
--- a/src/matcher/gui/menu/UidMenu.java
+++ b/src/matcher/gui/menu/UidMenu.java
@@ -308,7 +308,7 @@ public class UidMenu extends Menu {
 			if (!fields.isEmpty()) {
 				fields.sort(MemberInstance.nameComparator);
 
-				for (FieldInstance field : cls.getFields()) {
+				for (FieldInstance field : fields) {
 					field.setUid(nextFieldUid++);
 					assert field.getAllHierarchyMembers().size() == 1;
 				}


### PR DESCRIPTION
Doesn't make that much of a difference in the grand scheme of things (given there's no field hierarchy to worry about like methods), but since all the fields are being collected anyway might as well make it consistent with methods.