### PR TITLE
Update Fernflower

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,19 +28,19 @@ sourceSets {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_11
-	targetCompatibility = JavaVersion.VERSION_11
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 
-	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 		toolchain {
-			languageVersion = JavaLanguageVersion.of(11)
+			languageVersion = JavaLanguageVersion.of(17)
 		}
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	it.options.release = 11
+	it.options.release = 17
 }
 
 javafx {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ version = 0.1.0
 # Dependencies
 asm_version = 9.4
 fabric_cfr_version = 0.2.0
-fabric_fernflower_version = 1.5.0
+fabric_fernflower_version = 2.0.0
 procyon_version = 0.6.0
 mappingio_version = 0.3.0
 javaparser_version = 3.24.2
-javafx_version = 11.0.2
+javafx_version = 17.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ version = 0.1.0
 # Dependencies
 asm_version = 9.4
 fabric_cfr_version = 0.2.0
-fabric_fernflower_version = 1.3.0
+fabric_fernflower_version = 1.5.0
 procyon_version = 0.6.0
 mappingio_version = 0.3.0
 javaparser_version = 3.24.2

--- a/src/matcher/srcprocess/Fernflower.java
+++ b/src/matcher/srcprocess/Fernflower.java
@@ -31,6 +31,7 @@ import org.jetbrains.java.decompiler.struct.IDecompiledData;
 import org.jetbrains.java.decompiler.struct.StructClass;
 import org.jetbrains.java.decompiler.struct.StructContext;
 import org.jetbrains.java.decompiler.struct.lazy.LazyLoader;
+import org.jetbrains.java.decompiler.util.DataInputFullStream;
 import org.jetbrains.java.decompiler.util.TextBuffer;
 
 import matcher.NameType;
@@ -159,8 +160,9 @@ public class Fernflower implements Decompiler {
 			String name = cls.getName(nameType);
 			byte[] data = bcProvider.get(name); // BytecodeProvider has a name->byte[] cache to avoid redundant cls.serialize invocations
 			if (data == null) throw new IllegalStateException();
+			DataInputFullStream in = new DataInputFullStream(data);
 
-			StructClass cl = new StructClass(data, isOwn, loader);
+			StructClass cl = StructClass.create(in, isOwn, loader);
 			classes.put(cl.qualifiedName, cl);
 
 			ContextUnit unit = isOwn ? ownedUnit : unownedUnit;


### PR DESCRIPTION
Fernflower 2.0.0 requires Java 17, so this PR bumps Matcher's minimum version to 17, too.

Depends on #18.