### PR TITLE
Make classifiers publicly accessible

### DIFF
--- a/src/matcher/classifier/MethodClassifier.java
+++ b/src/matcher/classifier/MethodClassifier.java
@@ -365,7 +365,7 @@ public class MethodClassifier {
 	}
 
 	public abstract static class AbstractClassifier implements IClassifier<MethodInstance> {
-		AbstractClassifier(String name) {
+		public AbstractClassifier(String name) {
 			this.name = name;
 		}
 

--- a/src/matcher/classifier/MethodVarClassifier.java
+++ b/src/matcher/classifier/MethodVarClassifier.java
@@ -22,7 +22,7 @@ public class MethodVarClassifier {
 		addClassifier(usage, 8);
 	}
 
-	private static void addClassifier(AbstractClassifier classifier, double weight, ClassifierLevel... levels) {
+	public static void addClassifier(AbstractClassifier classifier, double weight, ClassifierLevel... levels) {
 		if (levels.length == 0) levels = ClassifierLevel.ALL;
 
 		classifier.weight = weight;
@@ -114,8 +114,8 @@ public class MethodVarClassifier {
 		}
 	};
 
-	private abstract static class AbstractClassifier implements IClassifier<MethodVarInstance> {
-		AbstractClassifier(String name) {
+	public abstract static class AbstractClassifier implements IClassifier<MethodVarInstance> {
+		public AbstractClassifier(String name) {
 			this.name = name;
 		}
 


### PR DESCRIPTION
Some `AbstractClassifier`s are private, while others are public. One that previously was public accidentally became package-private in #19 (see [here](https://github.com/sfPlayer1/Matcher/commit/d6e7623312e2c971be1c8de8f595f13922bcb7f7#diff-1f040caf194bcc7b3aa769078dbcbdc827f0997ff08caa626e1d04ca0269e9fcR368)) This PR makes them all public so plugins can add their own classifiers.