### PR TITLE
Expose transitive module dependencies as API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'java'
+	id 'java-library'
 	id 'application'
 	id 'maven-publish'
 	id "checkstyle"
@@ -35,6 +35,8 @@ java {
 			languageVersion = JavaLanguageVersion.of(17)
 		}
 	}
+
+	withSourcesJar()
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -53,15 +55,15 @@ javafx {
 }
 
 dependencies {
+	api "org.ow2.asm:asm:${asm_version}"
+	api "org.ow2.asm:asm-tree:${asm_version}"
+	api "net.fabricmc:mapping-io:${mappingio_version}"
+	implementation "org.ow2.asm:asm-commons:${asm_version}"
+	implementation "org.ow2.asm:asm-util:${asm_version}"
 	implementation "com.github.javaparser:javaparser-core:${javaparser_version}"
 	implementation "net.fabricmc:cfr:${fabric_cfr_version}"
 	implementation "net.fabricmc:fabric-fernflower:${fabric_fernflower_version}"
-	implementation "net.fabricmc:mapping-io:${mappingio_version}"
 	implementation "org.bitbucket.mstrobel:procyon-compilertools:${procyon_version}"
-	implementation "org.ow2.asm:asm:${asm_version}"
-	implementation "org.ow2.asm:asm-commons:${asm_version}"
-	implementation "org.ow2.asm:asm-tree:${asm_version}"
-	implementation "org.ow2.asm:asm-util:${asm_version}"
 
 	// JavaFX for all platforms (needed for cross-platform fat jar)
 	runtimeOnly "org.openjfx:javafx-base:${javafx_version}:win"

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -20,8 +20,8 @@ module matcher {
 	requires transitive javafx.graphics;
 	requires transitive javafx.web;
 	requires transitive org.objectweb.asm;
-	requires org.objectweb.asm.commons;
 	requires transitive org.objectweb.asm.tree;
+	requires org.objectweb.asm.commons;
 	requires org.objectweb.asm.tree.analysis;
 	requires org.objectweb.asm.util;
 	requires procyon.compilertools;


### PR DESCRIPTION
So Matcher plugins don't have to declare the dependencies themselves.